### PR TITLE
Add multiple columns for tablet view.

### DIFF
--- a/BrQTable.vue
+++ b/BrQTable.vue
@@ -45,7 +45,7 @@
       <!-- Mobile Support Prop -->
       <template v-slot:item="props">
         <div
-          class="q-pt-xs q-px-sm q-pb-sm col-xs-12
+          class="q-pt-xs q-px-sm q-pb-sm col-xs-12 col-sm-6
             col-md-4 col-lg-3 profile-card">
           <q-card
             bordered
@@ -132,8 +132,12 @@ export default {
 </script>
 <style lang="scss">
 
-.profile-card:last-of-type {
-  border-bottom: solid 1px rgba(0,0,0,0.12);
+.profile-card:first-child {
+  margin: auto;
+}
+
+.q-table--grid .q-table__bottom {
+  border-top: solid 1px rgba(0,0,0,0.12);
 }
 
 </style>


### PR DESCRIPTION
I still feel like we need to keep the text aligned center. It looks odd when it is hugged to the left.

## Tablet View

Single Item
![Screen Shot 2020-03-13 at 10 04 54 AM](https://user-images.githubusercontent.com/22648574/76638880-d2e10380-6512-11ea-9e88-edeedfd40d9b.png)


Multiple Items
![Screen Shot 2020-03-13 at 10 05 28 AM](https://user-images.githubusercontent.com/22648574/76638900-da081180-6512-11ea-848c-3baf370b285d.png)

## Mobile View
![Screen Shot 2020-03-13 at 10 05 42 AM](https://user-images.githubusercontent.com/22648574/76638918-e0968900-6512-11ea-82b3-3e88ad9a6dca.png)
